### PR TITLE
[PaintingPicker] Scrap previous namespaces to prevent IllegalArgumentExceptions for custom paintings

### DIFF
--- a/src/main/java/me/teakivy/teakstweaks/packs/paintingpicker/PaintingPicker.java
+++ b/src/main/java/me/teakivy/teakstweaks/packs/paintingpicker/PaintingPicker.java
@@ -53,6 +53,7 @@ public class PaintingPicker extends BasePack {
 
         for (Art art : registry) {
             String name = art.toString();
+            if (name.contains(":")) name = name.substring(name.indexOf(":") + 1);
             ItemStack item = ItemStack.of(Material.PAINTING);
             item.setData(DataComponentTypes.PAINTING_VARIANT, art);
 


### PR DESCRIPTION
You are using Art#toString() to create the namespaced key necessary for registering recipes.
This works fine for vanilla paintings, but for custom ones, it might include their origin's namespace (e.g. `painting_stellarity:a_hop_and_a_skip_away`), which is bad because the key must not include non-[a-z0-9_-./] characters.
This PR simply removes previous namespaces, if present, before attempting to create the key.